### PR TITLE
Feature pose hints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   pcl_ros
   visualization_msgs
+  tf_conversions
 )
 
 add_message_files(
@@ -97,7 +98,7 @@ generate_messages(
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES yak
-  CATKIN_DEPENDS cv_bridge image_transport rosconsole roscpp sensor_msgs pcl_ros visualization_msgs
+  CATKIN_DEPENDS cv_bridge image_transport rosconsole roscpp sensor_msgs pcl_ros visualization_msgs Eigen3 tf_conversions
 )
 
 

--- a/include/yak/kfusion/kinfu.hpp
+++ b/include/yak/kfusion/kinfu.hpp
@@ -7,6 +7,8 @@
 #include <vector>
 #include <string>
 
+#include <tf/transform_listener.h>
+
 namespace kfusion
 {
     namespace cuda
@@ -26,7 +28,7 @@ namespace kfusion
             int cols;  //pixels
             int rows;  //pixels
 
-            Intr intr;  //Camera parameters
+            Intr intr;  //Camera intrinsic parameters
 
             Vec3i volume_dims; //number of voxels
             Vec3f volume_size; //meters
@@ -41,7 +43,7 @@ namespace kfusion
             float icp_angle_thres;         //radians
             std::vector<int> icp_iter_num; //iterations for level index 0,1,..,3
 
-            float tsdf_min_camera_movement; //meters, integrate only if exceedes
+            float tsdf_min_camera_movement; //meters, integrate only if exceeds
             float tsdf_trunc_dist;             //meters;
             int tsdf_max_weight;               //frames
 
@@ -70,7 +72,7 @@ namespace kfusion
 
             void reset();
 
-            bool operator()(const cuda::Depth& dpeth, const cuda::Image& image = cuda::Image());
+            bool operator()(const Affine3f& poseHint, const cuda::Depth& depth, const cuda::Image& image = cuda::Image());
 
             void renderImage(cuda::Image& image, int flags = 0);
             void renderImage(cuda::Image& image, const Affine3f& pose, int flags = 0);
@@ -82,6 +84,7 @@ namespace kfusion
             int frame_counter_;
             KinFuParams params_;
 
+            // Sensor pose, currenly calculated  via ICP
             std::vector<Affine3f> poses_;
 
             cuda::Dists dists_;

--- a/include/yak/kfusion/kinfu.hpp
+++ b/include/yak/kfusion/kinfu.hpp
@@ -7,8 +7,6 @@
 #include <vector>
 #include <string>
 
-#include <tf/transform_listener.h>
-
 namespace kfusion
 {
     namespace cuda

--- a/include/yak/ros/kinfu_server.h
+++ b/include/yak/ros/kinfu_server.h
@@ -38,6 +38,7 @@
 #include <pcl/gpu/kinfu/tsdf_volume.h>
 
 #include <ros/half.hpp>
+#include <tf/transform_listener.h>
 
 //#include <Eigen/Sparse>
 

--- a/include/yak/ros/kinfu_server.h
+++ b/include/yak/ros/kinfu_server.h
@@ -88,7 +88,7 @@ namespace kfusion
             // Publishes the current camera transform.
             bool PublishTransform();
             // Does a single KinFu step given a depth and (optional) color image.
-            bool KinFu(const cv::Mat& depth, const cv::Mat& color);
+            bool KinFu(const Affine3f& poseHint, const cv::Mat& depth, const cv::Mat& color);
 
              inline bool ShouldExit() const { return should_exit_; }
              inline void SetExit(bool value) { should_exit_ = value; }
@@ -126,6 +126,7 @@ namespace kfusion
             tf::TransformBroadcaster tfBroadcaster_;
             cv::Mat lastDepth_;
             cv::Mat lastColor_;
+            Affine3f lastPoseHint_;
 
             ros::ServiceServer get_tsdf_server_;
             ros::ServiceServer get_sparse_tsdf_server_;

--- a/include/yak/ros/kinfu_server.h
+++ b/include/yak/ros/kinfu_server.h
@@ -9,6 +9,7 @@
 #define KINFUSERVER_H_
 
 #include <stdlib.h>
+#include <math.h>
 
 #include <iostream>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/include/yak/ros/kinfu_server.h
+++ b/include/yak/ros/kinfu_server.h
@@ -40,6 +40,12 @@
 #include <ros/half.hpp>
 #include <tf/transform_listener.h>
 
+#include "tf/transform_datatypes.h"
+#include "Eigen/Core"
+#include "Eigen/Geometry"
+#include <tf_conversions/tf_eigen.h>
+#include <opencv2/core/eigen.hpp>
+
 //#include <Eigen/Sparse>
 
 //#include <marching_cubes.h>

--- a/include/yak/ros/kinfu_server.h
+++ b/include/yak/ros/kinfu_server.h
@@ -105,10 +105,10 @@ namespace kfusion
              inline const std::string& GetCameraFrame() { return cameraFrame_; }
 
              // Service calls
+
              bool GetTSDF(yak::GetTSDFRequest& req, yak::GetTSDFResponse& res);
 
              bool GetSparseTSDF(yak::GetSparseTSDFRequest& req, yak::GetSparseTSDFResponse& res);
-             //bool GetMesh(yak::GetMeshRequest& req, yak::GetMeshResponse& res);
 
              bool TruncateTSDF(std::vector<uint32_t> &data, std::vector<uint32_t> &dataOut, std::vector<uint16_t> &rows, std::vector<uint16_t> &cols, std::vector<uint16_t> &sheets, int numVoxelsX, int numVoxelsY, int numVoxelsZ);
 
@@ -125,6 +125,11 @@ namespace kfusion
             std::string baseFrame_;
             std::string cameraFrame_;
             tf::TransformBroadcaster tfBroadcaster_;
+            tf::TransformListener tfListener_;
+
+            tf::StampedTransform current_world_to_sensor_transform_;
+            tf::StampedTransform previous_world_to_sensor_transform_;
+
             cv::Mat lastDepth_;
             cv::Mat lastColor_;
             Affine3f lastPoseHint_;

--- a/include/yak/ros/ros_rgbd_camera.hpp
+++ b/include/yak/ros/ros_rgbd_camera.hpp
@@ -58,6 +58,8 @@ namespace kfusion
             bool hasNewRGB;
             bool subscribedDepth;
             bool subscribedRGB;
+
+            ros::Time lastImageTime;
     };
 
 } /* namespace kfusion */

--- a/launch/launch_big.launch
+++ b/launch/launch_big.launch
@@ -1,8 +1,11 @@
 <launch>
     <!-- Remap the depth and color image topics to the ones output by the
          sensor of your choice -->
-    <remap from="/camera/depth/image_raw" to="/camera/depth/image_raw"/>
+    <!--<remap from="/camera/depth/image_raw" to="/camera/depth/image_raw"/>
     <remap from="/camera/rgb/image_rect_color" to="/camera/rgb/image_rect_color"/>
+    -->
+    <remap from="/camera/depth/image_raw" to="/depth/image"/>
+    <remap from="/camera/rgb/image_rect_color" to="/depth/image"/>
     
     <!-- Launch kinfu as a standalone ROS node-->
     <node name="kinfu" pkg="yak" type="kinfu_node" output="screen">
@@ -57,9 +60,9 @@
             tsdf_trunc_dist: 0.04
 
             # The size of the TSDF volume in voxels
-            volume_dims_x: 736
-            volume_dims_y: 736
-            volume_dims_z: 736
+            volume_dims_x: 704
+            volume_dims_y: 704
+            volume_dims_z: 704
 
             # The size of the TSDF volume in meters. The size of a voxel is 
             # volume_size / volume_dims

--- a/launch/launch_ensenso.launch
+++ b/launch/launch_ensenso.launch
@@ -57,9 +57,13 @@
             tsdf_trunc_dist: 0.04
 
             # The size of the TSDF volume in voxels
-            volume_dims_x: 704
-            volume_dims_y: 704
-            volume_dims_z: 704
+            #volume_dims_x: 704
+            #volume_dims_y: 704
+            #volume_dims_z: 704
+            volume_dims_x: 512
+            volume_dims_y: 512
+            volume_dims_z: 512
+
 
             # The size of the TSDF volume in meters. The size of a voxel is 
             # volume_size / volume_dims

--- a/launch/launch_ensenso.launch
+++ b/launch/launch_ensenso.launch
@@ -23,8 +23,8 @@
             # These are parameters for the point-to-plane ICP. The
             # thresholds prevent ICP from converging to far away/inconsistent
             # data.
-            icp_angle_thresh: 0.523599
-            icp_dist_thresh: 0.1
+            icp_angle_thresh: 0.25
+            icp_dist_thresh: 0.05
             icp_truncate_depth_dist: 0
 
             # ICP gets performed over an image pyramid of depth. These are the
@@ -67,9 +67,9 @@
 
             # The size of the TSDF volume in meters. The size of a voxel is 
             # volume_size / volume_dims
-            volume_size_x: 0.75
-            volume_size_y: 0.75
-            volume_size_z: 0.75
+            volume_size_x: 1.5
+            volume_size_y: 1.5
+            volume_size_z: 1.5
 
             # The position of the topmost corner of the TSDF volume in meters
             volume_pos_x: 0.5

--- a/launch/launch_xtion.launch
+++ b/launch/launch_xtion.launch
@@ -1,8 +1,8 @@
 <launch>
     <!-- Remap the depth and color image topics to the ones output by the
          sensor of your choice -->
-    <remap from="/camera/depth/image_raw" to="/depth/image"/>
-    <remap from="/camera/rgb/image_rect_color" to="/depth/image"/>
+     <remap from="/camera/depth/image_raw" to="/camera/depth/image_raw"/>
+     <remap from="/camera/rgb/image_rect_color" to="/camera/rgb/image_rect_color"/>
     
     <!-- Launch kinfu as a standalone ROS node-->
     <node name="kinfu" pkg="yak" type="kinfu_node" output="screen">

--- a/launch/launch_xtion.launch
+++ b/launch/launch_xtion.launch
@@ -63,9 +63,9 @@
 
             # The size of the TSDF volume in meters. The size of a voxel is 
             # volume_size / volume_dims
-            volume_size_x: 0.75
-            volume_size_y: 0.75
-            volume_size_z: 0.75
+            volume_size_x: 1.5
+            volume_size_y: 1.5
+            volume_size_z: 1.5
 
             # The position of the topmost corner of the TSDF volume in meters
             volume_pos_x: 0.5

--- a/package.xml
+++ b/package.xml
@@ -17,8 +17,13 @@
   <depend>sensor_msgs</depend>
   <depend>tf</depend>
   <depend>pcl_ros</depend>
-  <depend>cpu_tsdf</depend>
   <depend>visualization_msgs</depend>
+  <depend>Eigen3</depend>
+  <depend>tf_conversions</depend>
+
+
+
+
 
   <export>
   </export>

--- a/src/projective_icp.cpp
+++ b/src/projective_icp.cpp
@@ -196,7 +196,10 @@ bool kfusion::cuda::ProjectiveICP::estimateTransform(Affine3f& affine, const Int
     StreamHelper& sh = *shelp_;
 
     device::ComputeIcpHelper helper(dist_thres_, angle_thres_);
-    affine = Affine3f::Identity();
+
+    // This is equivalent to assuming that the transform between the previous and current pose is identity, i.e. the poses are identical.
+    // Changing this to the actual transform between the prev and TF-derived current pose should help the calculation of the new pose.
+    //affine = Affine3f::Identity();
 
     for (int level_index = LEVELS - 1; level_index >= 0; --level_index)
     {

--- a/src/ros/kinfu_server.cpp
+++ b/src/ros/kinfu_server.cpp
@@ -64,21 +64,19 @@ namespace kfusion
         tf::Transform past_to_current_sensor = previous_world_to_sensor_transform_.inverse() * current_world_to_sensor_transform_;
 
 
-        ROS_INFO_STREAM("Sensor transform (X): " << past_to_current_sensor.getOrigin().getX());
+        //ROS_INFO_STREAM("Sensor transform (X): " << past_to_current_sensor.getOrigin().getX());
 
-        //lastPoseHint_ = Affine3f::Identity();
-        //lastPoseHint_ = (Affine3f)past_to_current_sensor;
         Eigen::Affine3d lastPoseHintTemp;
         tf::transformTFToEigen(past_to_current_sensor, lastPoseHintTemp);
-        //lastPoseHintTemp.
-        //Eigen::Affine3f lastPoseHintFloatTemp = lastPoseHintTemp.cast<float>();
-
         cv::Mat tempOut(4,4, CV_32F);
         cv::eigen2cv(lastPoseHintTemp.cast<float>().matrix(), tempOut);
         lastPoseHint_ = Affine3f(tempOut);
-        //lastPoseHint_ = lastPoseHintTemp.cast<float>();
 
-        ROS_INFO_STREAM("Sensor transform (X): " << lastPoseHint_.matrix);
+        ros::Duration timeElapsed = current_world_to_sensor_transform_.stamp_ - previous_world_to_sensor_transform_.stamp_;
+        ROS_INFO_STREAM("deltaT: " << timeElapsed << " s");
+        double distanceMoved = sqrt(pow(past_to_current_sensor.getOrigin().getX(),2) + pow(past_to_current_sensor.getOrigin().getY(),2) + pow(past_to_current_sensor.getOrigin().getZ(),2));
+        ROS_INFO_STREAM("deltaD: " << distanceMoved << " m");
+        //ROS_INFO_STREAM("Sensor transform: " << lastPoseHint_.matrix);
 
         bool has_image = KinFu(lastPoseHint_, lastDepth_, lastColor_);
 

--- a/src/ros/kinfu_server.cpp
+++ b/src/ros/kinfu_server.cpp
@@ -80,7 +80,7 @@ namespace kfusion
     bool KinFuServer::KinFu(const Affine3f& poseHint, const cv::Mat& depth, const cv::Mat& color)
     {
         depthDevice_.upload(depth.data, depth.step, depth.rows, depth.cols);
-        return(* kinfu_)(depthDevice_);
+        return(* kinfu_)(lastPoseHint_, depthDevice_);
     }
 
     bool KinFuServer::ConnectCamera()

--- a/src/ros/kinfu_server.cpp
+++ b/src/ros/kinfu_server.cpp
@@ -35,7 +35,10 @@ namespace kfusion
     
     void KinFuServer::Update()
     {
+        // Try to grab an image from the camera. If it doesn't work, spin once and try again.
         bool has_frame = camera_->Grab(lastDepth_, lastColor_);
+
+        lastPoseHint_ = Affine3f::Identity();
 
         if (!has_frame)
         {
@@ -43,7 +46,7 @@ namespace kfusion
             return;
         }
 
-        bool has_image = KinFu(lastDepth_, lastColor_);
+        bool has_image = KinFu(lastPoseHint_, lastDepth_, lastColor_);
 
         if (has_image)
         {
@@ -62,6 +65,7 @@ namespace kfusion
 
         kfusion::KinFu& kinfu = *kinfu_;
 
+        // TODO: Need to change this to reflect actual sensor refresh rate? (e.g. Ensenso at ~4Hz)
         ROS_INFO("Starting tracking...\n");
         ros::Rate trackHz(30.0f);
         for (int i = 0; !should_exit_ && ros::ok(); ++i)
@@ -73,7 +77,7 @@ namespace kfusion
         return true;
     }
 
-    bool KinFuServer::KinFu(const cv::Mat& depth, const cv::Mat& color)
+    bool KinFuServer::KinFu(const Affine3f& poseHint, const cv::Mat& depth, const cv::Mat& color)
     {
         depthDevice_.upload(depth.data, depth.step, depth.rows, depth.cols);
         return(* kinfu_)(depthDevice_);
@@ -133,12 +137,20 @@ namespace kfusion
         volPosY = params.volume_pose.translation().val[1];
         volPosZ = params.volume_pose.translation().val[2];
 
+        ROS_INFO_STREAM("volPos (default): " << volPosX << ", " << volPosY << ", " << volPosZ);
+
         LoadParam(volPosX, "volume_pos_x");
         LoadParam(volPosY, "volume_pos_y");
         LoadParam(volPosZ, "volume_pos_z");
 
+        ROS_INFO_STREAM("volPos (loaded): " << volPosX << ", " << volPosY << ", " << volPosZ);
+        ROS_INFO_STREAM("translation: " << cv::Affine3f::Vec3(volPosX, volPosY, volPosZ));
+// problem's here somewhere????
+//        params.volume_pose = Affine3f().translate(Vec3f(volPosX, volPosY,volPosZ));
+
         params.volume_pose.translate(-params.volume_pose.translation());
         params.volume_pose.translate(cv::Affine3f::Vec3(volPosX, volPosY, volPosZ));
+
 
         kinfu_ = KinFu::Ptr(new kfusion::KinFu(params));
         return true;

--- a/src/ros/ros_rgbd_camera.cpp
+++ b/src/ros/ros_rgbd_camera.cpp
@@ -79,6 +79,7 @@ namespace kfusion
         lastDepthImage = image;
         lastDepthInfo = cameraInfo;
         hasNewDepth = true;
+
     }
 
     void RosRGBDCamera::RGBCallback(const sensor_msgs::ImageConstPtr& image, const sensor_msgs::CameraInfoConstPtr& cameraInfo)


### PR DESCRIPTION
Subscribe to robot kinematic poses published through ROS TF and use them as the initial sensor pose guess during ICP instead of assuming that the sensor hasn't moved between readings. Should improve quality of reconstructions while using sensors with low framerates or when scanning surfaces that return few valid depth readings.